### PR TITLE
Added lxml to list of dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4==4.4.1
+lxml==3.6.4
 requests==2.9.1


### PR DESCRIPTION
**Bug:**

```
Traceback (most recent call last):
  <REDACTED> in
    obj.urlinfo()
  File "<REDACTED>/myawis/__init__.py", line 58, in urlinfo
    soup=BeautifulSoup(r.text.encode('utf-8'),'xml')
  File "<REDACTED>/lib/python2.7/site-packages/bs4/__init__.py", line 156, in __init__
    % ",".join(features))
bs4.FeatureNotFound: Couldn't find a tree builder with the features you requested: xml. Do you need to install a parser library?
```

**Solution:**

`pip install lxml`